### PR TITLE
Formatting samples folder correctly on Windows

### DIFF
--- a/samplesToJSON.js
+++ b/samplesToJSON.js
@@ -2,8 +2,14 @@ const dirTree = require("directory-tree");
 const fs = require('fs');
 const tree = dirTree("./samples");
 
+// Replace double backslashes with forward slashes
+function convertWindowsPath(inputPath) {
+  return inputPath.replace(/\\/g, '/');
+}
+
 function formatItem(name, url) {
     const [, ext] = name.split(".");
+	url = convertWindowsPath(url);
             const group = url.split("/")[url.split("/").length - 2];
             return ['wav', 'aif', 'mp3'].includes(ext) 
                 ? { group, url: 'http://localhost:6060/' + url }


### PR DESCRIPTION
Today I tried to use Zen with custom samples from a Windows machine, and discovered that the samples folder wasn't being formatted properly due to the backslash path format '\\' instead of unix-based '/'. As a result, while loading zen with zen-connect, it accumulated all banks under `undefined`.

By currently parsing this path (as attempted in this PR), I was able to load the samples folder on Windows successfully. What is left to check is whether or not this breaks something on unix..